### PR TITLE
Extract setup into script

### DIFF
--- a/egg-cuberite-skyblock.json
+++ b/egg-cuberite-skyblock.json
@@ -16,7 +16,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Cuberite\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y wget git\r\n\r\ncd \/mnt\/server\r\n\r\nwget https:\/\/builds.cuberite.org\/job\/Cuberite%20Linux%20x64%20Master\/lastSuccessfulBuild\/artifact\/Cuberite.tar.gz\r\n\r\ntar -xf Cuberite.tar.gz\r\n\r\necho \"New Version <---------------------\"\r\n\r\ncd Plugins\r\ngit clone https:\/\/github.com\/Seadragon91\/SkyBlock.git\r\ncd SkyBlock\r\ngit checkout rework",
+            "script": "#!\/bin\/bash\r\n\r\napt update\r\napt install -y git\r\n\r\ncd \/mnt\/server\r\n\r\ngit clone https:\/\/github.com\/equitas-mc\/server-skyblock-egg.git\r\ncd server-skyblock-egg\r\n./setup.sh",
             "container": "debian:buster-slim",
             "entrypoint": "bash"
         }

--- a/settings.ini
+++ b/settings.ini
@@ -1,0 +1,55 @@
+; This is the main server configuration
+; Most of the settings here can be configured using the webadmin interface, if enabled in webadmin.ini
+
+[Folders]
+ProtocolPalettes=Protocol
+
+[Authentication]
+Authenticate=1
+AllowBungeeCord=1
+Server=sessionserver.mojang.com
+Address=/session/minecraft/hasJoined?username=%USERNAME%&serverId=%SERVERID%
+
+[MojangAPI]
+NameToUUIDServer=api.mojang.com
+NameToUUIDAddress=/profiles/minecraft
+UUIDToProfileServer=sessionserver.mojang.com
+UUIDToProfileAddress=/session/minecraft/profile/%UUID%?unsigned=false
+
+[Server]
+Description=Cuberite - in C++!
+ShutdownMessage=Server shutdown
+MaxPlayers=100
+HardcoreEnabled=0
+AllowMultiLogin=0
+Ports=25565
+AllowMultiWorldTabCompletion=1
+DefaultViewDistance=10
+
+[RCON]
+Enabled=0
+
+[AntiCheat]
+LimitPlayerBlockChanges=1
+
+[PlayerData]
+LoadOfflinePlayerData=0
+LoadNamedPlayerData=1
+
+[Worlds]
+DefaultWorld=world
+World=world_nether
+World=world_the_end
+
+[WorldPaths]
+world=world
+world_nether=world_nether
+world_the_end=world_the_end
+
+[Plugins]
+Plugin=Core
+Plugin=ChatLog
+
+[DeadlockDetect]
+Enabled=1
+IntervalSec=20

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+apt update
+apt install -y wget
+cd /mnt/server
+
+wget https://builds.cuberite.org/job/Cuberite%20Linux%20x64%20Master/lastSuccessfulBuild/artifact/Cuberite.tar.gz
+tar -xf Cuberite.tar.gz
+
+cp /mnt/server/server-skyblock-egg/settings.ini
+cp /mnt/server/server-skyblock-egg/webadmin.ini
+
+cd Plugins
+git clone https://github.com/Seadragon91/SkyBlock.git
+cd SkyBlock
+git checkout rework

--- a/webadmin.ini
+++ b/webadmin.ini
@@ -1,0 +1,11 @@
+; This file controls the webadmin feature of Cuberite
+; It specifies whether webadmin is enabled, and what logins are allowed.
+; Username format: [User:*username*]
+; Password format: Password=*password*; for example:
+; [User:admin]
+; Password=admin
+; Please restart Cuberite to apply changes made in this file!
+
+[WebAdmin]
+Ports=8080
+Enabled=1


### PR DESCRIPTION
Having the script in the json is tricky to edit, also it seems on
reinstall the config files are not updated.

Instead in the install script checkout the repository and call the
setup.sh.
As the server have a fixed configuration we don't need to rely on any
configuration variables in pterodactyl.