### PR TITLE
Add recipes for Lapis and StoneBrick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,5 @@ FROM quay.io/parkervcp/pterodactyl-images:base_debian
 COPY . /home/container/server-egg
 USER root
 RUN ./server-egg/setup.sh
+
+EXPOSE 25603 26603

--- a/setup.sh
+++ b/setup.sh
@@ -18,3 +18,9 @@ ln -s ../../server-egg/BlockInteractions Cuberite/Plugins/BlockInteractions
 
 # Update permissions, allow skyblock.command for default rank
 sqlite3 Cuberite/Ranks.sqlite "INSERT INTO PermissionItem (PermGroupID, permission) SELECT 1, 'skyblock.command' WHERE NOT EXISTS (SELECT 1 FROM PermissionItem WHERE PermGroupID = 1 AND permission = 'skyblock.command');"
+
+echo "
+#*******************************************************#
+# Custom Crafts
+LapisLazuli, 3    = IronIngot, * | GoldIngot, *
+StoneBrick, 4   = Cobblestone,  1:1, 1:2, 2:1, 2:2" >> Cuberite/crafting.txt

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,2 @@
 docker build -t skyblock-server-egg .
-docker run --name server-skyblock-egg skyblock-server-egg:latest /bin/sh -c 'cd Cuberite && ./Cuberite'
-#docker rm server-skyblock-egg
+docker -D run --name server-skyblock-egg --rm --publish=25603:25603 --publish=26603:26603 -ti skyblock-server-egg:latest /bin/bash -c 'cd Cuberite && ./Cuberite'


### PR DESCRIPTION
To be able to gather LapisLazuli and StoneBrick in skyblock additional
recipes are added.

Proceed with tests: `./test.sh` builds and starts a docker container
with the skyblock server.

Fixes #12